### PR TITLE
fix: remove VCS repository reference from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,11 +8,5 @@
         "kevinrob/guzzle-cache-middleware": "4.*",
         "launchdarkly/openfeature-server": "^1.0",
         "open-feature/sdk": "^2.0"
-    },
-    "repositories": [
-        {
-            "type": "vcs",
-            "url": "https://github.com/launchdarkly/openfeature-php-server"
-        }
-    ]
+    }
 }


### PR DESCRIPTION
## Summary

Removes the VCS repository reference pointing to `https://github.com/launchdarkly/openfeature-php-server` from `composer.json`. The `launchdarkly/openfeature-server` package (v1.0.0) is available on Packagist, making the VCS source unnecessary. The VCS reference causes `composer install` to fail in environments without GitHub SSH access (e.g., CI containers, Docker) because Composer attempts an SSH clone of the repository.

## Review & Testing Checklist for Human

- [ ] **Confirm the VCS reference is no longer needed**: it may have been added intentionally to track a pre-release or development version. Verify that `^1.0` resolving from Packagist alone is the intended behavior.
- [ ] **Run `composer install && php main.php`** with `LAUNCHDARKLY_SDK_KEY` set and confirm the app starts, connects to LaunchDarkly, and evaluates the flag successfully.

### Notes
- The `launchdarkly/openfeature-server` package constraint (`^1.0`) is unchanged — only the repository source was removed.
- Packagist currently has version `1.0.0` of this package, which satisfies `^1.0`.

Link to Devin session: https://app.devin.ai/sessions/08f3cd3234064ec88a183840412143ee
Requested by: @kinyoklion