### PR TITLE
chore: update guzzle-cache-middleware from 4.x to 7.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "license": "Apache-2.0",
     "require": {
         "php": ">=8.1",
-        "kevinrob/guzzle-cache-middleware": "4.*",
+        "kevinrob/guzzle-cache-middleware": "^7.0",
         "launchdarkly/openfeature-server": "^1.0",
         "open-feature/sdk": "^2.0"
     }


### PR DESCRIPTION
## Summary
Update `kevinrob/guzzle-cache-middleware` from `4.*` to `^7.0` to fix PHP 8.4+ deprecation warnings about implicit nullable parameters.

The LD PHP SDK uses guzzle-cache-middleware via `GuzzleFeatureRequester` for HTTP response caching in polling mode. The v7 API is backward-compatible — `CacheMiddleware`, `PublicCacheStrategy`, and `Psr6CacheStorage` all retain the same interfaces.

## Review & Testing Checklist for Human
- [ ] Run `composer install && php main.php` and verify no deprecation warnings appear
- [ ] Verify flag evaluation still works correctly

### Notes
Tested with PHP 8.4 via Docker — no deprecation warnings with v7, app evaluates flags correctly.

Link to Devin session: https://app.devin.ai/sessions/b648d8cd5e0b4a04ba0cbf1dcd1a9886
Requested by: @kinyoklion